### PR TITLE
hbs extension support for visual studio code

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ let languages = [
     name: 'Handlebars',
     extensions: ['.hbs'],
     parsers: ['hbs']
-  },
+  }
 ];
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = {
   languages,
   parsers,
   printers: {
-    hbs: GlimmerPrinter,
+    hbs: GlimmerPrinter
   },
   options: {},
   defaultOptions: {

--- a/index.js
+++ b/index.js
@@ -4,19 +4,20 @@ let GlimmerPrinter = require('./printer');
 let languages = [
   {
     name: 'Handlebars',
-    parsers: ['hbs']
-  }
+    extensions: ['.hbs'],
+    parsers: ['hbs'],
+  },
 ];
 
 module.exports = {
   languages,
   parsers,
   printers: {
-    hbs: GlimmerPrinter
+    hbs: GlimmerPrinter,
   },
   options: {},
   defaultOptions: {
     singleQuote: true,
-    tabWidth: 2
-  }
+    tabWidth: 2,
+  },
 };

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ let languages = [
   {
     name: 'Handlebars',
     extensions: ['.hbs'],
-    parsers: ['hbs'],
+    parsers: ['hbs']
   },
 ];
 
@@ -18,6 +18,6 @@ module.exports = {
   options: {},
   defaultOptions: {
     singleQuote: true,
-    tabWidth: 2,
-  },
+    tabWidth: 2
+  }
 };

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@glimmer/syntax": "^0.47.9"
+    "@glimmer/syntax": "^0.54"
   },
   "devDependencies": {
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.5"
   }
 }


### PR DESCRIPTION
Thanks for putting together this plugin!

I've been trying to use this on standalone `.hbs` files (for Ghost templates), and haven't gotten the plugin to parse these files.

**However,** I've found that manually specifying the file extension makes things work better:

before:
```
#  ./node_modules/.bin/prettier test.hbs
test.hbs[error] No parser could be inferred for file: test.hbs
```

after:
```
# ./node_modules/.bin/prettier test.hbs
<p>
  Hello {{user}}
</p>%
```

## Visual Studio Code

For this to work in vscode, you’ll need to add the override manually to `.prettierrc`:

```jsonc
// .prettierrc
  "overrides": [
    {
      "files": "*.hbs",
      "options": {
        "parser": "hbs"
      }
    }
  ]
```

and you‘ll need to trick the stock `esbenp.prettier-vscode` plugin to parse `.hbs.` files by adding this to your vscode `settings.json`:
```jsonc
  "files.associations": {
    "*.hbs": "html"
  }
```

**Note: ** If you do something the glimmer plugin doesn’t like (for instance, hbs partials), it will fail to format your document. It's a little hard to find, but the console output will read the following if this is the case:
```
["ERROR" - 2:40:26 PM] Error formatting document.
```

Also, I upversioned the prettier & glimmer package.json requirements, too.